### PR TITLE
Bug Fix for IM Loss for Action Spaces > 1

### DIFF
--- a/rllte/xplore/reward/e3b.py
+++ b/rllte/xplore/reward/e3b.py
@@ -219,6 +219,8 @@ class E3B(BaseReward):
             # use a random mask to select a subset of the training data
             mask = th.rand(len(im_loss), device=self.device)
             mask = (mask < self.update_proportion).type(th.FloatTensor).to(self.device)
+            # expand the mask to match action spaces > 1
+            mask = mask.unsqueeze(1).expand_as(im_loss)
             # get the masked loss
             im_loss = (im_loss * mask).sum() / th.max(
                 mask.sum(), th.tensor([1], device=self.device, dtype=th.float32)

--- a/rllte/xplore/reward/icm.py
+++ b/rllte/xplore/reward/icm.py
@@ -221,9 +221,11 @@ class ICM(BaseReward):
             # use a random mask to select a subset of the training data
             mask = th.rand(len(im_loss), device=self.device)
             mask = (mask < self.update_proportion).type(th.FloatTensor).to(self.device)
+            # expand the mask to match action spaces > 1
+            im_mask = mask.unsqueeze(1).expand_as(im_loss)
             # get the masked losses
-            im_loss = (im_loss * mask).sum() / th.max(
-                mask.sum(), th.tensor([1], device=self.device, dtype=th.float32)
+            im_loss = (im_loss * im_mask).sum() / th.max(
+                im_mask.sum(), th.tensor([1], device=self.device, dtype=th.float32)
             )
             fm_loss = (fm_loss * mask).sum() / th.max(
                 mask.sum(), th.tensor([1], device=self.device, dtype=th.float32)

--- a/rllte/xplore/reward/pseudo_counts.py
+++ b/rllte/xplore/reward/pseudo_counts.py
@@ -300,6 +300,8 @@ class PseudoCounts(BaseReward):
             # use a random mask to select a subset of the training data
             mask = th.rand(len(im_loss), device=self.device)
             mask = (mask < self.update_proportion).type(th.FloatTensor).to(self.device)
+            # expand the mask to match action spaces > 1
+            mask = mask.unsqueeze(1).expand_as(im_loss)
             # get the masked loss
             im_loss = (im_loss * mask).sum() / th.max(
                 mask.sum(), th.tensor([1], device=self.device, dtype=th.float32)

--- a/rllte/xplore/reward/ride.py
+++ b/rllte/xplore/reward/ride.py
@@ -338,9 +338,11 @@ class RIDE(BaseReward):
             # use a random mask to select a subset of the training data
             mask = th.rand(len(im_loss), device=self.device)
             mask = (mask < self.update_proportion).type(th.FloatTensor).to(self.device)
+            # expand the mask to match action spaces > 1
+            im_mask = mask.unsqueeze(1).expand_as(im_loss)
             # get the masked losses
-            im_loss = (im_loss * mask).sum() / th.max(
-                mask.sum(), th.tensor([1], device=self.device, dtype=th.float32)
+            im_loss = (im_loss * im_mask).sum() / th.max(
+                im_mask.sum(), th.tensor([1], device=self.device, dtype=th.float32)
             )
             fm_loss = (fm_loss * mask).sum() / th.max(
                 mask.sum(), th.tensor([1], device=self.device, dtype=th.float32)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Bug fix for adjusting the size of the mask to match the size of the im loss, which is not 1D when action space is greater than 1.

## Description
<!--- Describe your changes in detail -->
In rewards that use im_loss (ICM, E3B, RIDE, and pseudo counts), I repeated the same mask value by the action dim. Since the im_loss and fm_loss share the same mask anyway, I chose to keep the same mask when adding values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
closes #52 
- [ ] I have raised an issue to propose this change ([required](https://github.com/RLE-Foundation/rllte/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've read the [CONTRIBUTION](https://github.com/RLE-Foundation/rllte/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have opened an associated PR on the [rllte-hub repository](https://github.com/RLE-Foundation/rllte-hub) (if necessary)
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)
- [ ] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->