### PR TITLE
Bug fix for NGU module's AttributeError

### DIFF
--- a/rllte/xplore/reward/ngu.py
+++ b/rllte/xplore/reward/ngu.py
@@ -121,6 +121,8 @@ class NGU(Fabric):
             weight_init=weight_init,
         )
 
+        self.mrs = mrs
+        
         super().__init__(*[rnd, pseudo_counts])
 
     def compute(self, samples: Dict[str, th.Tensor], sync: bool = True) -> th.Tensor:


### PR DESCRIPTION
Hello, thank you for providing high quality frameworks that provides various intrinsic reward modules.
However, I found a minor issue from the reward module `NGU`: #55

This PR fixes the issue #55.

```
AttributeError: 'NGU' object has no attribute 'mrs'
```

## Description
The variable `mrs` was not being assigned to the instance variable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/RLE-Foundation/rllte/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've read the [CONTRIBUTION](https://github.com/RLE-Foundation/rllte/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have opened an associated PR on the [rllte-hub repository](https://github.com/RLE-Foundation/rllte-hub) (if necessary)
- [ ] I have reformatted the code using `make format` (**required**)
- [] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [] I have ensured `make pytest` and `make type` both pass. (**required**)
- [] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->